### PR TITLE
feat : 주문 번호 채번 객체 새로 구현

### DIFF
--- a/domain/src/main/java/com/example/application/OrderCodeSequence.java
+++ b/domain/src/main/java/com/example/application/OrderCodeSequence.java
@@ -1,0 +1,11 @@
+package com.example.application;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class OrderCodeSequence {
+
+    public static String create(LocalDateTime now) {
+        return now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")) + String.format("%04d", (int) (Math.random() * 9998 + 1));
+    }
+}

--- a/domain/src/main/java/com/example/application/OrderService.java
+++ b/domain/src/main/java/com/example/application/OrderService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Service
 public class OrderService {
@@ -30,7 +29,7 @@ public class OrderService {
     }
 
     @Transactional
-    public String order(Long productId, int quantity, Long memberId, LocalDateTime now) {
+    public String order(Long productId, int quantity, Long memberId) {
         // 상품 재고 확인
         Product product = productRepository.getLockBy(productId);
         product.checkQuantity(quantity);
@@ -44,7 +43,7 @@ public class OrderService {
         // 주문서 생성
         Order order = Order.builder()
                 .memberId(memberId)
-                .ordersCode(now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + String.format("%04d", (int) (Math.random() * 9998 + 1)))
+                .ordersCode(OrderCodeSequence.create(LocalDateTime.now()))
                 .build();
         Order createOrder = orderRepository.save(order);
 

--- a/ecommerce-api/src/main/java/com/example/controller/OrderController.java
+++ b/ecommerce-api/src/main/java/com/example/controller/OrderController.java
@@ -21,6 +21,6 @@ public class OrderController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public String order(@RequestBody OrderRequest request, @AuthMember Long memberId) {
-        return orderService.order(request.productId(), request.quantity(), memberId, LocalDateTime.now());
+        return orderService.order(request.productId(), request.quantity(), memberId);
     }
 }


### PR DESCRIPTION
- 주문 번호 중복 처리 해결 위해 주문번호 생성 객체 구현
- 기존 LocalDateTime은 controller에서 파라미터로 넘겨주는데
- lock 구간 전 전달 해주기 때문에 동시성이 발생된다.
- 기존 로직으로 한 이유는 비즈니스 로직에는 변화되는 데이터는 외부로 빼야 테스트 코드나 안정성이 높기 때문에 구현
- 하지만 관점을 조금만 바꾸면 
- 주문 번호 객체를 생성하므로 주문번호 생성 관점을 다른 곳에 둠
- 따라서 orderservice에서 LocalDateTime 사용 가능